### PR TITLE
[Docs] Change the command in README to "Select Interpreter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This VS Code extension from the Modular team adds support for the
 
 ### Mojo SDK Resolution
 
-The extension relies on the Python extension for locating your Python environment. In some cases, this appears to default to your globally-installed environment, even when a virtual environment exists. If the Mojo extension cannot find your SDK installation, try invoking the `Python: Set Project Environment` command and selecting your virtual environment.
+The extension relies on the Python extension for locating your Python environment. In some cases, this appears to default to your globally-installed environment, even when a virtual environment exists. If the Mojo extension cannot find your SDK installation, try invoking the `Python: Select Interpreter` command and selecting your virtual environment.
 
 ## Debugger
 


### PR DESCRIPTION
People have encountered challenges in following the README instructions for setting the right interpreter location due to the command being slightly different. This changes the command to `Python: Select Interpreter`, which is what this on all of my VS Code installations.